### PR TITLE
Use stable URL for IREE pip-release-links.

### DIFF
--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/jax/scripts/setup_venv.sh
@@ -29,7 +29,7 @@ python -m pip install --upgrade pip || echo "Could not upgrade pip"
 
 # Get iree-ir-tool for IR postprocessing.
 python -m pip install \
-  --find-links https://openxla.github.io/iree/pip-release-links.html \
+  --find-links https://iree.dev/pip-release-links.html \
   iree-compiler
 
 if [ -z "$WITH_CUDA" ]; then

--- a/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/scripts/setup_venv.sh
+++ b/common_benchmark_suite/openxla/benchmark/comparative_suite/tflite/scripts/setup_venv.sh
@@ -27,7 +27,7 @@ python -m pip install --upgrade pip || echo "Could not upgrade pip"
 
 # Get IREE tools for importing and binarizing.
 python -m pip install \
-  --find-links https://openxla.github.io/iree/pip-release-links.html \
+  --find-links https://iree.dev/pip-release-links.html \
   iree-compiler \
   iree-tools-tflite
 


### PR DESCRIPTION
The `openxla.github.io` link depends on a specific GitHub organization, and the IREE repo will be moving soon (multiple times). The `iree.dev` release links URL is recommended here: https://iree.dev/reference/bindings/python/#prebuilt-packages